### PR TITLE
feat: Implement Windows-specific handling for socket management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,16 @@
 module github.com/jpillora/overseer
 
-go 1.13
+go 1.24
+
+toolchain go1.24.2
 
 require (
+	github.com/Microsoft/go-winio v0.6.2
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
-	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/jpillora/s3 v1.1.4
+)
+
+require (
+	github.com/go-ole/go-ole v1.2.4 // indirect
+	golang.org/x/sys v0.10.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
@@ -8,3 +10,5 @@ github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHei
 github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/gunit v1.1.3 h1:32x+htJCu3aMswhPw3teoJ+PnWPONqdNgaGs6Qt8ZaU=
 github.com/smartystreets/gunit v1.1.3/go.mod h1:EH5qMBab2UclzXUcpR8b93eHsIlp9u+pDQIRp5DZNzQ=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/proc_master.go
+++ b/proc_master.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/Microsoft/go-winio"
 )
 
 var tmpBinPath = filepath.Join(os.TempDir(), "overseer-"+token()+extension())
@@ -461,8 +463,8 @@ func extension() string {
 	return ""
 }
 
-// checkSocketsReleasedOnWindows is a Windows-specific function that periodically
-// checks if the slave process has created a file indicating it has released its sockets
+// checkSocketsReleasedOnWindows is a Windows-specific function that waits for 
+// the slave process to signal via named pipe that it has released its sockets
 func (mp *master) checkSocketsReleasedOnWindows() {
 	if runtime.GOOS != "windows" {
 		return
@@ -475,18 +477,43 @@ func (mp *master) checkSocketsReleasedOnWindows() {
 			continue
 		}
 		
-		// Check for the release file
-		tempFile := os.TempDir() + "/overseer-" + strconv.Itoa(mp.slaveID) + "-released"
-		if _, err := os.Stat(tempFile); err == nil {
-			// File exists, slave has released sockets
-			mp.debugf("windows: detected socket release via file")
-			mp.awaitingUSR1 = false
-			mp.descriptorsReleased <- true
-			
-			// Clean up the file
-			os.Remove(tempFile)
+		// Create a named pipe to wait for slave's signal
+		pipeName := fmt.Sprintf(`\\.\pipe\overseer-release-%d`, mp.slaveID)
+		mp.debugf("windows: listening for release signal on pipe %s", pipeName)
+		
+		// Set up the pipe server with security descriptor allowing access to everyone
+		pc := &winio.PipeConfig{
+			SecurityDescriptor: "D:P(A;;GA;;;AU)",
+			MessageMode:        true,
+			InputBufferSize:    1024,
+			OutputBufferSize:   1024,
 		}
 		
-		time.Sleep(100 * time.Millisecond)
+		listener, err := winio.ListenPipe(pipeName, pc)
+		if err != nil {
+			mp.warnf("windows: failed to create pipe: %s", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		
+		// Accept connection from slave
+		conn, err := listener.Accept()
+		if err != nil {
+			listener.Close()
+			mp.warnf("windows: pipe accept error: %s", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		
+		// Read message (don't really need the content)
+		buf := make([]byte, 1024)
+		_, err = conn.Read(buf)
+		conn.Close()
+		listener.Close()
+		
+		// Received signal from slave
+		mp.debugf("windows: received socket release signal via pipe")
+		mp.awaitingUSR1 = false
+		mp.descriptorsReleased <- true
 	}
 }

--- a/proc_master.go
+++ b/proc_master.go
@@ -112,6 +112,12 @@ func (mp *master) setupSignalling() {
 			mp.handleSignal(s)
 		}
 	}()
+	
+	// On Windows, we need to periodically check for the temporary file
+	// that indicates the slave has released its sockets
+	if runtime.GOOS == "windows" {
+		go mp.checkSocketsReleasedOnWindows()
+	}
 }
 
 func (mp *master) handleSignal(s os.Signal) {
@@ -155,6 +161,15 @@ func (mp *master) sendSignal(s os.Signal) {
 
 func (mp *master) retreiveFileDescriptors() error {
 	mp.slaveExtraFiles = make([]*os.File, len(mp.Config.Addresses))
+	
+	// On Windows, we don't use file descriptors as they are not supported for TCP sockets
+	if runtime.GOOS == "windows" {
+		// Instead of using file descriptors, we'll save the addresses
+		// and let the slave process recreate the listeners
+		return nil
+	}
+	
+	// POSIX implementation (unchanged)
 	for i, addr := range mp.Config.Addresses {
 		a, err := net.ResolveTCPAddr("tcp", addr)
 		if err != nil {
@@ -354,15 +369,24 @@ func (mp *master) fork() error {
 	e = append(e, envBinPath+"="+mp.binPath)
 	e = append(e, envSlaveID+"="+strconv.Itoa(mp.slaveID))
 	e = append(e, envIsSlave+"=1")
-	e = append(e, envNumFDs+"="+strconv.Itoa(len(mp.slaveExtraFiles)))
+	
+	// Windows does not support passing file descriptors between processes
+	// So we'll pass 0 and use addresses directly in slave
+	if runtime.GOOS == "windows" {
+		e = append(e, envNumFDs+"=0")
+	} else {
+		e = append(e, envNumFDs+"="+strconv.Itoa(len(mp.slaveExtraFiles)))
+		//include socket files for non-Windows platforms
+		cmd.ExtraFiles = mp.slaveExtraFiles
+	}
+	
 	cmd.Env = e
 	//inherit master args/stdfiles
 	cmd.Args = os.Args
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	//include socket files
-	cmd.ExtraFiles = mp.slaveExtraFiles
+	
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("Failed to start slave process: %s", err)
 	}
@@ -435,4 +459,34 @@ func extension() string {
 	}
 
 	return ""
+}
+
+// checkSocketsReleasedOnWindows is a Windows-specific function that periodically
+// checks if the slave process has created a file indicating it has released its sockets
+func (mp *master) checkSocketsReleasedOnWindows() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	
+	for {
+		// Only check when we're actually waiting for a release
+		if !mp.awaitingUSR1 {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		
+		// Check for the release file
+		tempFile := os.TempDir() + "/overseer-" + strconv.Itoa(mp.slaveID) + "-released"
+		if _, err := os.Stat(tempFile); err == nil {
+			// File exists, slave has released sockets
+			mp.debugf("windows: detected socket release via file")
+			mp.awaitingUSR1 = false
+			mp.descriptorsReleased <- true
+			
+			// Clean up the file
+			os.Remove(tempFile)
+		}
+		
+		time.Sleep(100 * time.Millisecond)
+	}
 }

--- a/proc_slave.go
+++ b/proc_slave.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"time"
 )
@@ -84,6 +85,13 @@ func (sp *slave) initFileDescriptors() error {
 	if err != nil {
 		return fmt.Errorf("invalid %s integer", envNumFDs)
 	}
+	
+	// On Windows, we create listeners directly instead of using file descriptors
+	if runtime.GOOS == "windows" {
+		return sp.initWindowsListeners()
+	}
+	
+	// POSIX file descriptor handling
 	sp.listeners = make([]*overseerListener, numFDs)
 	sp.state.Listeners = make([]net.Listener, numFDs)
 	for i := 0; i < numFDs; i++ {
@@ -99,6 +107,35 @@ func (sp *slave) initFileDescriptors() error {
 	if len(sp.state.Listeners) > 0 {
 		sp.state.Listener = sp.state.Listeners[0]
 	}
+	return nil
+}
+
+// initWindowsListeners creates listeners directly on Windows instead of using file descriptors
+func (sp *slave) initWindowsListeners() error {
+	sp.listeners = make([]*overseerListener, len(sp.Config.Addresses))
+	sp.state.Listeners = make([]net.Listener, len(sp.Config.Addresses))
+	
+	for i, addr := range sp.Config.Addresses {
+		a, err := net.ResolveTCPAddr("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("Invalid address %s (%s)", addr, err)
+		}
+		
+		// Try to listen on the address
+		l, err := net.ListenTCP("tcp", a)
+		if err != nil {
+			return fmt.Errorf("Failed to listen on: %s (%s)", addr, err)
+		}
+		
+		u := newOverseerListener(l)
+		sp.listeners[i] = u
+		sp.state.Listeners[i] = u
+	}
+	
+	if len(sp.state.Listeners) > 0 {
+		sp.state.Listener = sp.state.Listeners[0]
+	}
+	
 	return nil
 }
 
@@ -121,7 +158,15 @@ func (sp *slave) watchSignal() {
 			//a new process before this child has actually exited.
 			//early restarts not supported with restarts disabled.
 			if !sp.NoRestart {
-				sp.masterProc.Signal(SIGUSR1)
+				// On Windows, we need to handle SIGUSR1 differently
+				if runtime.GOOS == "windows" {
+					// On Windows, use a different approach to signal the master
+					// Simply create a temporary file that the master can detect
+					sp.debugf("windows: signaling master that sockets are released")
+					sp.descriptorsReleased()
+				} else {
+					sp.masterProc.Signal(SIGUSR1)
+				}
 			}
 			//listeners should be waiting on connections to close...
 		}
@@ -132,6 +177,24 @@ func (sp *slave) watchSignal() {
 			os.Exit(1)
 		}()
 	}()
+}
+
+// descriptorsReleased is a Windows-specific function to inform the master process
+// that socket descriptors are released
+func (sp *slave) descriptorsReleased() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	
+	// On Windows, we can't use signals the same way as on POSIX systems
+	// So we'll create a temporary file to indicate the sockets are released
+	tempFile := os.TempDir() + "/overseer-" + sp.id + "-released"
+	f, err := os.Create(tempFile)
+	if err != nil {
+		sp.warnf("failed to create release file: %s", err)
+		return
+	}
+	f.Close()
 }
 
 func (sp *slave) triggerRestart() {

--- a/proc_slave.go
+++ b/proc_slave.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/Microsoft/go-winio"
 )
 
 var (
@@ -180,21 +182,44 @@ func (sp *slave) watchSignal() {
 }
 
 // descriptorsReleased is a Windows-specific function to inform the master process
-// that socket descriptors are released
+// that socket descriptors are released using a named pipe
 func (sp *slave) descriptorsReleased() {
 	if runtime.GOOS != "windows" {
 		return
 	}
 	
-	// On Windows, we can't use signals the same way as on POSIX systems
-	// So we'll create a temporary file to indicate the sockets are released
-	tempFile := os.TempDir() + "/overseer-" + sp.id + "-released"
-	f, err := os.Create(tempFile)
+	// Create the pipe name that master is listening on
+	pipeName := fmt.Sprintf(`\\.\pipe\overseer-release-%s`, sp.id)
+	sp.debugf("windows: signaling socket release via pipe %s", pipeName)
+	
+	// Try to connect a few times with backoff
+	var err error
+	var conn net.Conn
+	
+	for attempts := 0; attempts < 5; attempts++ {
+		// Connect to the named pipe
+		conn, err = winio.DialPipe(pipeName, nil)
+		if err == nil {
+			break
+		}
+		sp.debugf("windows: pipe connection attempt %d failed: %s", attempts+1, err)
+		time.Sleep(time.Duration(attempts+1) * 200 * time.Millisecond)
+	}
+	
 	if err != nil {
-		sp.warnf("failed to create release file: %s", err)
+		sp.warnf("windows: failed to connect to master pipe: %s", err)
 		return
 	}
-	f.Close()
+	
+	// Send a simple message
+	_, err = conn.Write([]byte("released"))
+	if err != nil {
+		sp.warnf("windows: failed to write to pipe: %s", err)
+	}
+	
+	// Close the connection
+	conn.Close()
+	sp.debugf("windows: socket release signal sent via pipe")
 }
 
 func (sp *slave) triggerRestart() {


### PR DESCRIPTION
- Added periodic checking for socket release on Windows in proc_master.
- Updated file descriptor handling to create listeners directly in proc_slave for Windows.
- Introduced temporary file signaling mechanism for socket release notification on Windows.
- Ensured compatibility with non-Windows systems by maintaining existing POSIX logic.